### PR TITLE
Refactoring monitor layout for rofi

### DIFF
--- a/monitor_layout.sh
+++ b/monitor_layout.sh
@@ -89,7 +89,7 @@ function gen_entries()
 {
     for a in $(seq 0 $(( ${#TILES[@]} -1 )))
     do
-        echo $a ${TILES[a]}
+        echo "$a: ${TILES[a]}"
     done
 }
 
@@ -97,4 +97,4 @@ function gen_entries()
 SEL=$( gen_entries | rofi -dmenu -p "Monitor Setup:" -a 0 -no-custom  | awk '{print $1}' )
 
 # Call xrandr
-$( ${COMMANDS[$SEL]} )
+$( ${COMMANDS[${SEL::-1}]} )

--- a/monitor_layout.sh
+++ b/monitor_layout.sh
@@ -55,7 +55,7 @@ do
         then
             TILES[$index]="Dual Screen ${MONITORS[$entry_a]} -> ${MONITORS[$entry_b]}"
             COMMANDS[$index]="xrandr --output ${MONITORS[$entry_a]} --auto \
-                              --output ${MONITORS[$entry_b]} --auto --left-of ${MONITORS[$entry_a]}"
+                              --output ${MONITORS[$entry_b]} --auto --right-of ${MONITORS[$entry_a]}"
 
             index+=1
         fi

--- a/monitor_layout.sh
+++ b/monitor_layout.sh
@@ -9,8 +9,7 @@ MONITORS=( $( ${XRANDR} | awk '( $2 == "connected" ){ print $1 }' ) )
 
 NUM_MONITORS=${#MONITORS[@]}
 
-TITLES=()
-COMMANDS=()
+
 
 
 function gen_xrandr_only()

--- a/monitor_layout.sh
+++ b/monitor_layout.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+#
+# Allows to manage screens with rofi using implicitly xrandr.
 
 XRANDR=$(which xrandr)
 

--- a/monitor_layout.sh
+++ b/monitor_layout.sh
@@ -94,7 +94,7 @@ function gen_entries()
 }
 
 # Call menu
-SEL=$( gen_entries | rofi -dmenu -p "Monitor Setup:" -a 0 -no-custom  | awk '{print $1}' )
+SEL=$( gen_entries | rofi -dmenu -p "Monitor Setup:" -no-custom  | awk '{print $1}' )
 
 # Call xrandr
 $( ${COMMANDS[${SEL::-1}]} )

--- a/monitor_layout.sh
+++ b/monitor_layout.sh
@@ -49,11 +49,11 @@ function gen_options() {
 	    do
 		if [ $i != $j ]; then
 		    if [ "$1" == "clone" ]; then
-			TILES[$index]="Clone Screen ${MONITORS[$i]} -> ${MONITORS[$j]}"
+			TILES[$index]="Clone Screen ${MONITORS[$i]}  ${MONITORS[$j]}"
 			COMMANDS[$index]="xrandr --output ${MONITORS[$i]} --auto \
                               --output ${MONITORS[$j]} --auto --same-as ${MONITORS[$i]}"
 		    elif [ "$1" == "dual" ]; then
-			TILES[$index]="Dual Screen ${MONITORS[$i]} -> ${MONITORS[$j]}"
+			TILES[$index]="Dual Screen ${MONITORS[$i]}  ${MONITORS[$j]}"
 			COMMANDS[$index]="xrandr --output ${MONITORS[$i]} --auto \
                               --output ${MONITORS[$j]} --auto \
 			       --right-of ${MONITORS[$i]}"


### PR DESCRIPTION
First of all, I want to thank you for your work. I allowed myself to refactor the code for the `monitor_layout.sh` script.

This refactorization includes:
- Adding global documentation
- Deleting unnecessary variables.
- Display correction for dual screen: it is more logical that (**A** -> **B**) means that **A** is to the **left** of **B**.
- Better display by adding two points after the number (**0 Cancel -> 0: Cancel**).
- Redundant code reduction.
- Arrows with Font Awesome 5 (can be removed if you want to avoid dependencies).

**NOTE:** before accepting this pull request, it would first be wise to first accept this [one](https://github.com/carnager/rofi-scripts/pull/10)

My apologies for the reversal of order.