### PR TITLE
Change `file` to `folder` to fix a error

### DIFF
--- a/rofi-finder/README.md
+++ b/rofi-finder/README.md
@@ -33,6 +33,6 @@ If you want to find a folder containing a file you can type ```?<search_query>``
 
 ![Rofi Finder 4](rofi-finder-4.png)
 
-If you see ```??``` at the end of the result line you can press enter to open the file containing that file.
+If you see ```??``` at the end of the result line you can press enter to open the folder containing that file.
 
 ![Rofi Finder 5](rofi-finder-5.png)


### PR DESCRIPTION
The `file` should be appeared as `folder` as the context describes.