### PR TITLE
 add script to crawl history of PDF viewer zathura 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Rofi based scripts
 
-
 ## i3_switch_workspace.sh
 
 ### Usage
@@ -8,6 +7,7 @@
 ```bash
 ./i3_switch_workspace.sh
 ```
+
 ### Screenshot
 
 ![I3 Workspace Switcher](i3_switch_workspace.png)
@@ -19,6 +19,7 @@
 ```bash
 ./monitor_layout.sh
 ```
+
 ### Screenshot
 
 ![Monitor Layout](monitor_layout.png)
@@ -27,3 +28,79 @@
 
 Tries to generate colors from current Gtk+-3.0 theme.
 Based on code in Mate-HUD.
+
+### Screenshot
+
+![Monitor Layout](monitor_layout.png)
+
+## zathist.sh
+
+A shell script to fuzzy find (and open) from `rofi` (or `dmenu`) a PDF file in the history of the zathura viewer.
+
+### Installation
+
+To use this script most conveniently:
+
+1. Save this script, say to `~/bin/zathist.sh` by
+
+    ```sh
+    mkdir --parents ~/bin &&
+    curl -fLo https://raw.githubusercontent.com/Konfekt/zathist.sh/master/zathist.sh ~/bin/zathist.sh
+    ```
+  
+1. mark it executable by `chmod a+x ~/bin/zathist.sh`,
+
+To launch `zathist.sh` by a global keyboard shortcut, say pressing at the same time the `Microsoft Windows` key and `Z`:
+
+1. install, say, `Xbindkeys` (or `Sxhkd`), (for example, on `openSUSE` by `sudo zypper install xbindkeys` respectively `sudo zypper install sxhkd`)
+1. add to `~/.xbindkeysrc` a shortcut that launches `zathist.sh`, say
+
+    ```sh
+    "$HOME/bin/zathist.sh"
+    Mod4 + z
+    ```
+
+1. start `xbindkeys`.
+
+To start `xbindkeys` automatically at login, say on a `KDE` desktop environment, put a file `xbindkeys.sh` reading
+
+```sh
+#! /bin/sh
+xbindkeys
+```
+
+into `~/.config/autostart-scripts/`.
+
+### Configuration
+
+PDFs whose path matches the pattern given by the variable
+
+```sh
+    IGNORE_REGEX="^${TMPDIR:-/tmp}/\|_cropped\.pdf$"
+```
+
+will not be listed.
+
+`zathist.sh` uses rofi in dmenu mode.
+Replace at will by dmenu itself and change its command line arguments by the variables
+
+```sh
+MENU_ENGINE=-rofi
+MENU_ARGS="-dmenu -i -keep-right"
+```
+
+To customize the prompt and theme, adapt the variables
+
+```
+THEME='
+element{ horizontal-align: 0; }
+listview {
+    dynamic: true;
+    padding: 0px 0px 0px ;
+}'
+PROMPT='❯ '
+```
+
+### Credits
+
+This shell script refines shell code posted on [stackexchange](https://unix.stackexchange.com/questions/467524/open-file-from-history-in-zathura).

--- a/zathist.sh
+++ b/zathist.sh
@@ -1,0 +1,41 @@
+#! /bin/sh
+#
+# Open a PDF file in the history of the zathura viewer from rofi.
+#
+# Save this script as executable ~/bin/zathist.sh, install Xbindkeys
+# (or Sxhkd) and, say, add to ~/.xbindkeysrc the shortcut
+#
+# "$HOME/bin/zathist.sh"
+#   Control + Alt + z
+# 
+# This shell script refines https://unix.stackexchange.com/questions/467524/open-file-from-history-in-zathura
+
+# PDFs whose path matches this pattern will not be listed
+[ -z "${IGNORE_REGEX:++}" ] &&
+  IGNORE_REGEX="^${TMPDIR:-/tmp}/\|_cropped\.pdf\|_optimized\.pdf$" 
+
+[ -z "${THEME:++}" ] &&
+THEME='
+element{ horizontal-align: 0; }
+listview {
+    dynamic: true;
+    padding: 0px 0px 0px ;
+}'
+PROMPT=${PROMPT:-'❯ '}
+# uses rofi in dmenu mode; replace by dmenu itself at will
+
+MENU_ENGINE=${MENU_ENGINE:-rofi}
+MENU_ARGS="${MENU_ARGS:--dmenu -i -keep-right}"
+
+# regex from https://github.com/lucc/config/blob/d416378290d25b9a61cd8252f7ecf98a294dd80f/rofi/bin/mru.sh#L7
+selection=$(
+  sed -n '/^\[.\+\]$/h;/^time=[0-9]\+$/{x;G;s/^\[\(.\+\)\]\ntime=\([0-9]\+\)$/\2 \1/p}' "${XDG_DATA_HOME:-$HOME/.local/share}/zathura/history" |
+    sort -nr | cut -d ' ' -f 2- |
+    grep -v "$IGNORE_REGEX" |
+    while IFS= read -r f; do [ -f "$f" ] && echo "$f"; done |
+    sed "s#^${HOME}/#~/#" |
+    ${MENU_ENGINE} ${MENU_ARGS} -theme-str "$THEME" -p "$PROMPT" |
+    sed "s#^~/#${HOME}/#"
+)
+[ -r "$selection" ] || exit
+nohup zathura "$selection" </dev/null >/dev/null 2>&1 &


### PR DESCRIPTION
Adds a shell script to fuzzy find (and open) from `rofi` (or `dmenu`) a PDF file in the history of the zathura viewer.
